### PR TITLE
CS-123 Added ECSET code generation:

### DIFF
--- a/csatar-plugins/csatar/Plugin.php
+++ b/csatar-plugins/csatar/Plugin.php
@@ -5,6 +5,7 @@ use Backend;
 use System\Classes\PluginBase;
 use ValidationException;
 use Lang;
+use RainLab\User\Models\User;
 
 /**
  * csatar Plugin Information File
@@ -43,6 +44,8 @@ class Plugin extends PluginBase
      */
     public function boot()
     {
+        $this->extendUser();
+
         App::error(function(\October\Rain\Auth\AuthException $exception) {
             return Lang::get('csatar.csatar::lang.frontEnd.authException');
         });
@@ -70,5 +73,14 @@ class Plugin extends PluginBase
         return [
             'csatar.csatar::mail.restore'
         ];
+    }
+
+    protected function extendUser()
+    {
+        User::extend(function($model) {
+            $model->hasOne['scout'] = [
+                \Csatar\Csatar\Models\Scout::class
+            ];
+        });
     }
 }

--- a/csatar-plugins/csatar/lang/en/lang.php
+++ b/csatar-plugins/csatar/lang/en/lang.php
@@ -19,6 +19,8 @@
                 'select' => 'Select...',
                 'logo' => 'Logo',
                 'coordinates' => 'Coordinates',
+                'ecsetCode' => 'ECSET code',
+                'relations' => 'Relations',
             ],
             'scout' => [
                 'scout' => 'Scout',
@@ -43,6 +45,12 @@
                 'allergies' => 'Allergies',
                 'allergiesInfo' => 'Allergies can be added after the Scout has been created. Click the Create button after other information is filled.',
                 'breadcrumb' => 'Scouts',
+                'team' => 'Team',
+                'troop' => 'Troop',
+                'patrol' => 'Patrol',
+                'validationExceptions' => [
+                    'noTeamSelected' => 'Please select a team!'
+                ]
             ],
             'admin' => [
                 'menu' => [
@@ -107,6 +115,9 @@
                 'leadershipPresentation' => 'Leadership Presentation',
                 'districtsInfo' => 'Districts can be added after the Association has been created. Click the Create button after other information is filled.',
                 'breadcrumb' => 'Associations',
+                'ecsetCode' => [
+                    'suffix' => 'ECSET code suffix',
+                ],
             ],
             'district' => [
                 'district' => 'District',

--- a/csatar-plugins/csatar/models/Association.php
+++ b/csatar-plugins/csatar/models/Association.php
@@ -45,6 +45,7 @@ class Association extends Model
         'bank_account',
         'leadership_presentation',
         'logo',
+        'ecset_code_suffix',
     ];
 
     /**

--- a/csatar-plugins/csatar/models/Association.php
+++ b/csatar-plugins/csatar/models/Association.php
@@ -8,7 +8,7 @@ use Model;
 class Association extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-    
+
     use \October\Rain\Database\Traits\SoftDelete;
 
     protected $dates = ['deleted_at'];
@@ -30,6 +30,7 @@ class Association extends Model
         'bank_account' => 'min:5',
         'leadership_presentation' => 'required',
         'logo' => 'image|nullable',
+        'ecset_code_suffix' => 'required|max:2|alpha'
     ];
 
     /**
@@ -45,7 +46,7 @@ class Association extends Model
         'leadership_presentation',
         'logo',
     ];
-    
+
     /**
      * Relations
      */

--- a/csatar-plugins/csatar/models/Association.php
+++ b/csatar-plugins/csatar/models/Association.php
@@ -30,7 +30,7 @@ class Association extends Model
         'bank_account' => 'min:5',
         'leadership_presentation' => 'required',
         'logo' => 'image|nullable',
-        'ecset_code_suffix' => 'required|max:2|alpha'
+        'ecset_code_suffix' => 'max:2|alpha'
     ];
 
     /**

--- a/csatar-plugins/csatar/models/Patrol.php
+++ b/csatar-plugins/csatar/models/Patrol.php
@@ -8,7 +8,7 @@ use Model;
 class Patrol extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-    
+
     use \October\Rain\Database\Traits\SoftDelete;
 
     protected $dates = ['deleted_at'];
@@ -43,13 +43,13 @@ class Patrol extends Model
         if (!isset($this->team_id)) {
             return;
         }
-        
+
         // if the selected troop does not belong to the selected team, then throw and exception
         if ($this->troop_id && $this->troop->team->id != $this->team_id) {
             throw new \ValidationException(['troop' => \Lang::get('csatar.csatar::lang.plugin.admin.patrol.troopNotInTheTeamError')]);
         }
     }
-    
+
     /**
      * Handle the team-troop dependency
      */
@@ -81,20 +81,24 @@ class Patrol extends Model
         'troop_id',
         'logo',
     ];
-    
+
     /**
      * Relations
      */
-    
+
     public $belongsTo = [
         'team' => '\Csatar\Csatar\Models\Team',
         'troop' => '\Csatar\Csatar\Models\Troop',
     ];
 
+    public $hasMany = [
+        'scouts' => '\Csatar\Csatar\Models\Scout',
+    ];
+
     public $attachOne = [
         'logo' => 'System\Models\File'
     ];
-    
+
     /**
      * Scope a query to only include patrols with a given team id.
      */
@@ -102,7 +106,7 @@ class Patrol extends Model
     {
         return $query->where('team_id', $id);
     }
-    
+
     /**
      * Scope a query to only include patrols with a given troop id.
      */

--- a/csatar-plugins/csatar/models/Scout.php
+++ b/csatar-plugins/csatar/models/Scout.php
@@ -81,7 +81,7 @@ class Scout extends Model
         $team = Team::find($this->team_id);
 
         if(empty($team)){
-            throw new \ValidationException(['troop_id' => \Lang::get('csatar.csatar::lang.plugin.admin.patrol.troopNotInTheTeamError')]);
+            throw new \ValidationException(['team_id' => \Lang::get('csatar.csatar::lang.plugin.admin.scout.validationExceptions.noTeamSelected')]);
         }
 
         $sufix = $team->district->association->ecset_code_suffix ?? substr($team->district->association->name, 0, 2);

--- a/csatar-plugins/csatar/models/Scout.php
+++ b/csatar-plugins/csatar/models/Scout.php
@@ -40,7 +40,10 @@ class Scout extends Model
         'legal_relationship_id',
         'special_diet_id',
         'religion_id',
-        'tshirt_size_id'
+        'tshirt_size_id',
+        'team_id',
+        'troop_id',
+        'patrol_id',
     ];
 
     /**
@@ -50,7 +53,10 @@ class Scout extends Model
         'legal_relationship' => '\Csatar\Csatar\Models\LegalRelationship',
         'special_diet' => '\Csatar\Csatar\Models\SpecialDiet',
         'religion' => '\Csatar\Csatar\Models\Religion',
-        'tshirt_size' => '\Csatar\Csatar\Models\TShirtSize'
+        'tshirt_size' => '\Csatar\Csatar\Models\TShirtSize',
+        'team' => '\Csatar\Csatar\Models\Team',
+        'troop' => '\Csatar\Csatar\Models\Troop',
+        'patrol' => '\Csatar\Csatar\Models\Patrol',
     ];
 
     public $belongsToMany = [
@@ -64,4 +70,28 @@ class Scout extends Model
             'pivot' => ['details']
         ]
     ];
+
+    public function beforeCreate()
+    {
+        $this->ecset_code = strtoupper($this->generateEcsetCode());
+    }
+
+    private function generateEcsetCode(){
+
+        $team = Team::find($this->team_id);
+
+        if(empty($team)){
+            throw new \ValidationException(['troop_id' => \Lang::get('csatar.csatar::lang.plugin.admin.patrol.troopNotInTheTeamError')]);
+        }
+
+        $sufix = $team->district->association->ecset_code_suffix ?? substr($team->district->association->name, 0, 2);
+
+        $ecset_code = strtoupper(substr(uniqid(), 0, -3) . '-' . $sufix);
+
+        if(Scout::where('ecset_code', $ecset_code)->exists()){
+            return $this->generateEcsetCode();
+        }
+
+        return $ecset_code;
+    }
 }

--- a/csatar-plugins/csatar/models/Scout.php
+++ b/csatar-plugins/csatar/models/Scout.php
@@ -50,6 +50,7 @@ class Scout extends Model
      * Relations
      */
     public $belongsTo = [
+        'user' => '\Rainlab\User\Models\User',
         'legal_relationship' => '\Csatar\Csatar\Models\LegalRelationship',
         'special_diet' => '\Csatar\Csatar\Models\SpecialDiet',
         'religion' => '\Csatar\Csatar\Models\Religion',

--- a/csatar-plugins/csatar/models/Team.php
+++ b/csatar-plugins/csatar/models/Team.php
@@ -8,7 +8,7 @@ use Model;
 class Team extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-    
+
     use \October\Rain\Database\Traits\SoftDelete;
 
     protected $dates = ['deleted_at'];
@@ -93,11 +93,11 @@ class Team extends Model
         'home_supplier_name',
         'district_id',
     ];
-    
+
     /**
      * Relations
      */
-    
+
     public $belongsTo = [
         'district' => '\Csatar\Csatar\Models\District',
     ];
@@ -105,12 +105,13 @@ class Team extends Model
     public $hasMany = [
         'troops' => '\Csatar\Csatar\Models\Troop',
         'patrols' => '\Csatar\Csatar\Models\Patrol',
+        'scouts' => '\Csatar\Csatar\Models\Scout',
     ];
 
     public $attachOne = [
         'logo' => 'System\Models\File'
     ];
-    
+
     /**
      * Scope a query to only include teams with a given district id.
      */

--- a/csatar-plugins/csatar/models/Troop.php
+++ b/csatar-plugins/csatar/models/Troop.php
@@ -8,7 +8,7 @@ use Model;
 class Troop extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-    
+
     use \October\Rain\Database\Traits\SoftDelete;
 
     protected $dates = ['deleted_at'];
@@ -47,23 +47,24 @@ class Troop extends Model
         'troop_leader_email',
         'team_id',
     ];
-    
+
     /**
      * Relations
      */
-    
+
     public $belongsTo = [
         'team' => '\Csatar\Csatar\Models\Team',
     ];
 
     public $hasMany = [
         'patrols' => '\Csatar\Csatar\Models\Patrol',
+        'scouts' => '\Csatar\Csatar\Models\Scout',
     ];
 
     public $attachOne = [
         'logo' => 'System\Models\File'
     ];
-    
+
     /**
      * Scope a query to only include troops with a given team id.
      */

--- a/csatar-plugins/csatar/models/association/fields.yaml
+++ b/csatar-plugins/csatar/models/association/fields.yaml
@@ -1,6 +1,11 @@
 fields:
     name:
-        label: 'csatar.csatar::lang.plugin.admin.association.name'
+        label: 'csatar.csatar::lang.plugin.admin.association.association'
+        span: auto
+        required: 1
+        type: text
+    ecset_code_suffix:
+        label: 'csatar.csatar::lang.plugin.admin.association.ecsetCode.suffix'
         span: auto
         required: 1
         type: text

--- a/csatar-plugins/csatar/models/association/fields.yaml
+++ b/csatar-plugins/csatar/models/association/fields.yaml
@@ -7,7 +7,6 @@ fields:
     ecset_code_suffix:
         label: 'csatar.csatar::lang.plugin.admin.association.ecsetCode.suffix'
         span: auto
-        required: 1
         type: text
     coordinates:
         label: 'csatar.csatar::lang.plugin.admin.general.coordinates'

--- a/csatar-plugins/csatar/models/scout/columns.yaml
+++ b/csatar-plugins/csatar/models/scout/columns.yaml
@@ -85,3 +85,8 @@ columns:
         searchable: true
         relation: tshirt_size
         valueFrom: title
+    ecset_code:
+        label: 'csatar.csatar::lang.plugin.admin.general.ecsetCode'
+        type: text
+        searchable: true
+        sortable: true

--- a/csatar-plugins/csatar/models/scout/fields.yaml
+++ b/csatar-plugins/csatar/models/scout/fields.yaml
@@ -5,6 +5,38 @@ fields:
         disabled: 1
         readOnly: 1
         type: number
+    ecset_code:
+        label: 'csatar.csatar::lang.plugin.admin.general.ecsetCode'
+        span: auto
+        disabled: 1
+        readOnly: 1
+        type: text
+    relations:
+        label: 'csatar.csatar::lang.plugin.admin.general.relations'
+        span: full
+        type: section
+    team:
+        label: 'csatar.csatar::lang.plugin.admin.scout.team'
+        nameFrom: name
+        descriptionFrom: description
+        emptyOption: 'csatar.csatar::lang.plugin.admin.general.select'
+        span: auto
+        required: 1
+        type: relation
+    troop:
+        label: 'csatar.csatar::lang.plugin.admin.scout.troop'
+        nameFrom: name
+        descriptionFrom: description
+        emptyOption: 'csatar.csatar::lang.plugin.admin.general.select'
+        span: auto
+        type: relation
+    patrol:
+        label: 'csatar.csatar::lang.plugin.admin.scout.patrol'
+        nameFrom: name
+        descriptionFrom: description
+        emptyOption: 'csatar.csatar::lang.plugin.admin.general.select'
+        span: auto
+        type: relation
     scoutData:
         label: 'csatar.csatar::lang.plugin.admin.scout.scoutData'
         span: full
@@ -36,6 +68,7 @@ fields:
         emptyOption: 'csatar.csatar::lang.plugin.admin.general.select'
         showSearch: true
         span: auto
+        required: 1
         type: dropdown
     is_active:
         label: 'csatar.csatar::lang.plugin.admin.scout.isActive'

--- a/csatar-plugins/csatar/updates/builder_table_update_csatar_csatar_associations_2.php
+++ b/csatar-plugins/csatar/updates/builder_table_update_csatar_csatar_associations_2.php
@@ -1,0 +1,23 @@
+<?php namespace Csatar\Csatar\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableUpdateCsatarCsatarAssociations2 extends Migration
+{
+    public function up()
+    {
+        Schema::table('csatar_csatar_associations', function($table)
+        {
+            $table->string('ecset_code_suffix', 2)->nullable()->unique();
+        });
+    }
+    
+    public function down()
+    {
+        Schema::table('csatar_csatar_associations', function($table)
+        {
+            $table->dropColumn('ecset_code_suffix');
+        });
+    }
+}

--- a/csatar-plugins/csatar/updates/builder_table_update_csatar_csatar_scouts_9.php
+++ b/csatar-plugins/csatar/updates/builder_table_update_csatar_csatar_scouts_9.php
@@ -1,0 +1,29 @@
+<?php namespace Csatar\Csatar\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableUpdateCsatarCsatarScouts9 extends Migration
+{
+    public function up()
+    {
+        Schema::table('csatar_csatar_scouts', function($table)
+        {
+            $table->string('ecset_code', 14)->after('id')->unique()->nullable();
+            $table->integer('team_id')->after('ecset_code')->index('team_id')->nullable()->unsigned();
+            $table->integer('troop_id')->after('team_id')->index('troop_id')->nullable()->unsigned();
+            $table->integer('patrol_id')->after('troop_id')->index('patrol_id')->nullable()->unsigned();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('csatar_csatar_scouts', function($table)
+        {
+            $table->dropColumn('ecset_code');
+            $table->dropColumn('team_id');
+            $table->dropColumn('troop_id');
+            $table->dropColumn('patrol_id');
+        });
+    }
+}

--- a/csatar-plugins/csatar/updates/version.yaml
+++ b/csatar-plugins/csatar/updates/version.yaml
@@ -141,3 +141,9 @@
 1.0.50:
     - 'Added indexing to all foreign keys'
     - builder_add_indexing_to_all_foreign_keys.php
+1.0.51:
+    - 'Updated table csatar_csatar_scouts'
+    - builder_table_update_csatar_csatar_scouts_9.php
+1.0.52:
+    - 'Updated table csatar_csatar_associations'
+    - builder_table_update_csatar_csatar_associations_2.php

--- a/csatar-theme/pages/bejelentkezes.htm
+++ b/csatar-theme/pages/bejelentkezes.htm
@@ -12,7 +12,11 @@ requirePassword = 0
 <?php
 public function onStart(){
     if(Auth::user()){
-        return Redirect::to('/tag/'. Auth::user()->id);
+        if(!empty(Auth::user()->scout->ecset_code)) {
+            return Redirect::to('/tag/'. Auth::user()->scout->ecset_code);
+        } else {
+            return Redirect::to('/');
+        }
     }
 }
 ?>

--- a/csatar-theme/pages/tag.htm
+++ b/csatar-theme/pages/tag.htm
@@ -1,10 +1,10 @@
-url = "/tag/:id/:action?"
+url = "/tag/:ecset_code/:action?"
 layout = "basicAuth"
 title = "Tag"
 
 [basicForm]
-formId = 2
-recordKeyParam = "id"
+formId = 1
+recordKeyParam = "ecset_code"
 recordActionParam = "action"
 createRecordKeyword = "letrehozas"
 actionUpdateKeyword = "modositas"

--- a/csatar-theme/pages/tagok.htm
+++ b/csatar-theme/pages/tagok.htm
@@ -9,8 +9,8 @@ scopeValue = "{{ :scope }}"
 displayColumn = "family_name"
 noRecordsMessage = "No records found"
 detailsPage = "tag"
-detailsKeyColumn = "id"
-detailsUrlParameter = "id"
+detailsKeyColumn = "ecset_code"
+detailsUrlParameter = "ecset_code"
 pageNumber = "{{ :page }}"
 
 [viewBag]


### PR DESCRIPTION
- When Scout is saved a unique code is generated and concatenated with the Association suffix
- In order to achieve the above, Scout and Team relation was setup. Scout must belong to a Team, Team must belong to a District, District must belong to an Association
- Association was extended with an association suffix column
- /tag and /tagok page was updated to use 'ecset_code' to identify records instead of 'id'