### PR TITLE
CS-273 Model structure refactor for permission handling

### DIFF
--- a/csatar-plugins/csatar/models/Mandate.php
+++ b/csatar-plugins/csatar/models/Mandate.php
@@ -31,23 +31,23 @@ class Mandate extends Model
 
         // on the BE, when clicking the Mandate Create button: modify the mandate_model relation type, in order to the mandate_model relation to be set when creating a new mandate
         $this->belongsTo['mandate_model'] = Input::get('Association') !== null ?
-            Association::getOrganizationTypeModelName() :
+            Association::getModelName() :
             (Input::get('District') !== null ?
-                District::getOrganizationTypeModelName() :
+                District::getModelName() :
                 (Input::get('Team') !== null ?
-                   Team::getOrganizationTypeModelName() :
+                   Team::getModelName() :
                     (Input::get('Troop') !== null ?
-                       Troop::getOrganizationTypeModelName() :
+                       Troop::getModelName() :
                         (Input::get('Patrol') !== null ?
-                            Patrol::getOrganizationTypeModelName() :
-                            OrganizationBase::getOrganizationTypeModelName()))));
+                            Patrol::getModelName() :
+                            OrganizationBase::getModelName()))));
 
         // on the BE, when changing the Mandate Type on the form, which is shown after the Mandate Create button has been clicked: modify the mandate_model relation type, in order to the mandate_model relation to be set
-        if ($this->belongsTo['mandate_model'] == OrganizationBase::getOrganizationTypeModelName()) {
+        if ($this->belongsTo['mandate_model'] == OrganizationBase::getModelName()) {
             $mandate = Input::get('Mandate');
             $mandate_type_id = $mandate ? $mandate['mandate_type'] : null;
             $mandate_type = $mandate_type_id ? MandateType::find($mandate_type_id) : null;
-            $this->belongsTo['mandate_model'] = $mandate_type ? $mandate_type->organization_type_model_name : OrganizationBase::getOrganizationTypeModelName();
+            $this->belongsTo['mandate_model'] = $mandate_type ? $mandate_type->organization_type_model_name : OrganizationBase::getModelName();
         }
     }
 
@@ -116,7 +116,7 @@ class Mandate extends Model
     public function initFromForm($record)
     {
         // from the Organization page
-        $modelName = $record::getOrganizationTypeModelName();
+        $modelName = $record::getModelName();
         $this->mandate_model = $record;
         $this->mandate_model_type = $modelName;
         $this->mandate_model_name = $record->extendedName;
@@ -192,16 +192,16 @@ class Mandate extends Model
         $this->mandate_model_type = !$this->mandate_model_type ? $this->belongsTo['mandate_model'] : $this->mandate_model_type;
         $mandate_model_id = null;
         $mandate_model_type = null;
-        
+
         // in case of troops and patrols, allow anyone from the team. In case of other organization units, allow only scouts from that organization unit
         if (!$this->mandate_model_id && !$this->mandate_model) {
             // we are on a create form on the FE
             $inputData = Input::get('data');
             switch ($this->mandate_model_type) {
-                case Troop::getOrganizationTypeModelName():
-                case Patrol::getOrganizationTypeModelName():
+                case Troop::getModelName():
+                case Patrol::getModelName():
                     $mandate_model_id = $inputData['team'];
-                    $mandate_model_type = Team::getOrganizationTypeModelName();
+                    $mandate_model_type = Team::getModelName();
                     break;
 
                 default:
@@ -210,9 +210,9 @@ class Mandate extends Model
         }
         else {
             // we are on an edit form
-            if ($this->mandate_model_type == Troop::getOrganizationTypeModelName() || $this->mandate_model_type == Patrol::getOrganizationTypeModelName()) {
+            if ($this->mandate_model_type == Troop::getModelName() || $this->mandate_model_type == Patrol::getModelName()) {
                 $mandate_model_id = $this->mandate_model ? $this->mandate_model->team_id : null;
-                $mandate_model_type = Team::getOrganizationTypeModelName();
+                $mandate_model_type = Team::getModelName();
             }
             else {
                 $mandate_model_id = $this->mandate_model_id;
@@ -268,6 +268,6 @@ class Mandate extends Model
      */
     public function scopeMandateModelType($query, $model = null)
     {
-        return $model ? $query->where('mandate_model_type', $model::getOrganizationTypeModelName()) : $query->whereNull('id');
+        return $model ? $query->where('mandate_model_type', $model::getModelName()) : $query->whereNull('id');
     }
 }

--- a/csatar-plugins/csatar/models/MandateType.php
+++ b/csatar-plugins/csatar/models/MandateType.php
@@ -88,11 +88,11 @@ class MandateType extends Model
     function getOrganizationTypeModelNameOptions()
     {
         return [
-            Association::getOrganizationTypeModelName() => Association::getOrganizationTypeModelNameUserFriendly(),
-            District::getOrganizationTypeModelName() => District::getOrganizationTypeModelNameUserFriendly(),
-            Patrol::getOrganizationTypeModelName() => Patrol::getOrganizationTypeModelNameUserFriendly(),
-            Team::getOrganizationTypeModelName() => Team::getOrganizationTypeModelNameUserFriendly(),
-            Troop::getOrganizationTypeModelName() => Troop::getOrganizationTypeModelNameUserFriendly(),
+            Association::getModelName() => Association::getOrganizationTypeModelNameUserFriendly(),
+            District::getModelName() => District::getOrganizationTypeModelNameUserFriendly(),
+            Patrol::getModelName() => Patrol::getOrganizationTypeModelNameUserFriendly(),
+            Team::getModelName() => Team::getOrganizationTypeModelNameUserFriendly(),
+            Troop::getModelName() => Troop::getOrganizationTypeModelNameUserFriendly(),
         ];
     }
 
@@ -129,15 +129,15 @@ class MandateType extends Model
         else {
             $inputData = Input::get('data');
             if ($inputData && array_key_exists('association', $inputData) && !empty($inputData['association'])) {
-                $mandate_model_type = District::getOrganizationTypeModelName();
+                $mandate_model_type = District::getModelName();
                 $association_id = $inputData['association'];
             }
             else if ($inputData && array_key_exists('district', $inputData) && !empty($inputData['district'])) {
-                $mandate_model_type = Team::getOrganizationTypeModelName();
+                $mandate_model_type = Team::getModelName();
                 $association_id = District::find($inputData['district'])->getAssociationId();
             }
             else if ($inputData && array_key_exists('team', $inputData) && !empty($inputData['team'])) {
-                $mandate_model_type = array_key_exists('troop', $inputData) ? Patrol::getOrganizationTypeModelName() : Troop::getOrganizationTypeModelName();
+                $mandate_model_type = array_key_exists('troop', $inputData) ? Patrol::getModelName() : Troop::getModelName();
                 $association_id = Team::find($inputData['team'])->getAssociationId();
             }
         }

--- a/csatar-plugins/csatar/models/PermissionBasedAccess.php
+++ b/csatar-plugins/csatar/models/PermissionBasedAccess.php
@@ -1,0 +1,163 @@
+<?php namespace Csatar\Csatar\Models;
+
+use Csatar\Csatar\Classes\RightsMatrix;
+use Model;
+use Db;
+use RainLab\Builder\Classes\ModelModel;
+use RainLab\Builder\Classes\PluginCode;
+
+class PermissionBasedAccess extends Model
+{
+    /**
+     * @param $scout
+     * @return bool
+     * If scout has mandates for the specific record is considered own
+     */
+    public function isOwnModel($scout)
+    {
+
+        $mandates = $scout->getMandatesForOrganization($this);
+        return count($mandates) > 0;
+    }
+
+    /**
+     * Returns the id of the association to which the item belongs to.
+     */
+    public function getAssociationId()
+    {
+        if ($this->team_id) {
+            return $this->team->district->association->id;
+        }
+
+        return null;
+    }
+
+    public static function getModelName()
+    {
+        return '\\' . static::class;
+    }
+
+    public function getRightsForMandateTypes(array $mandateTypeIds = [], bool $own = false, bool $is2fa = false)
+    {
+
+        $associationId = $this->getAssociationId();
+
+        if (empty($associationId)) {
+            return;
+        }
+
+        if (empty($mandateTypeIds) && $guestMandateTypeId = MandateType::getGuestMandateTypeIdInAssociation($associationId)) {
+            $mandateTypeIds = [$guestMandateTypeId];
+        }
+
+        if (empty($mandateTypeIds)) {
+            return;
+        }
+
+        $rights = Db::table('csatar_csatar_mandates_permissions')
+            ->when(!$own, function ($query) {
+                return $query->where(
+                    function ($query) {
+                        return $query->where('own', '<>', 1)->orWhereNull('own');
+                    });
+            })
+            ->whereIn('mandate_type_id', $mandateTypeIds)
+            ->where('model', self::getModelName())
+            ->get();
+
+        $rights = $rights->groupBy('field');
+
+        return $rights->map(function ($item, $key) use ($is2fa) {
+            return [
+                'obligatory' => $is2fa ? $item->min('obligatory') : $item->min('obligatory') - 1,
+                'create' => $is2fa ? $item->max('create') : $item->max('create') - 1,
+                'read' => $is2fa ? $item->max('read') : $item->max('read') - 1,
+                'update' => $is2fa ? $item->max('update') : $item->max('update') - 1,
+                'delete' => $is2fa ? $item->max('delete') : $item->max('delete') - 1,
+                // in the permissions table we have 0 - if user has no permission, 1 - if has permission only with 2fa, 2 - if has permission without 2fa
+                // if logged in user has NO 2fa, we substract 1 from every value, so where 2fa permission is needed, value will be 0, and no permission is granted
+            ];
+        });
+    }
+
+    public function getGuestRightsForModel()
+    {
+        $associationId = $this->getAssociationId();
+        $modelName = $this::getModelName();
+        $key = $associationId . $modelName;
+
+        $sessionRecord = Session::get('guest.rightsForModels');
+        $sessionRecordForModel = $sessionRecord ? $sessionRecord->get($key) : null;
+
+        if (!empty($sessionRecordForModel) && $sessionRecordForModel['savedToSession'] >= RightsMatrix::getRightsMatrixLastUpdateTime() && $sessionRecordForModel['rights']->count() != 0) {
+            return $sessionRecordForModel['rights'];
+        }
+
+        if (empty($sessionRecord)) {
+            $sessionRecord = new Collection([]);
+        }
+
+        $rights = $this->getRightsForMandateTypes();
+        $sessionRecord = $sessionRecord->replace([
+            $key => [
+                'associationId' => $associationId,
+                'model' => $modelName,
+                'savedToSession' => date('Y-m-d H:i'),
+                'rights' => $rights,
+            ],
+        ]);
+
+        Session::put('guest.rightsForModels', $sessionRecord);
+
+        return $rights;
+    }
+
+    public static function getTranslatedAttributeNames(string $organizationTypeModelName = null): array
+    {
+        if ((is_array(self::$translatedAttributeNames) && !array_key_exists($organizationTypeModelName, self::$translatedAttributeNames)) ||
+            !is_array(self::$translatedAttributeNames)
+        ) {
+            $path = strtolower(str_replace('\\', DIRECTORY_SEPARATOR, plugins_path() . $organizationTypeModelName . '\\fields.yaml'));
+            $attributes = Yaml::parseFile($path);
+            foreach ($attributes['fields'] as $key => $attribute) {
+                self::$translatedAttributeNames[$organizationTypeModelName][$key] = Lang::get($attribute['label']);
+            }
+
+            // add labels from belongsTo->label
+            $model = new $organizationTypeModelName();
+            foreach ($model->belongsToMany as $realtionName => $relationData) {
+                if (is_array($relationData) && array_key_exists('label', $relationData)) {
+                    self::$translatedAttributeNames[$organizationTypeModelName][$realtionName] = Lang::get($relationData['label']);
+                }
+            }
+        }
+
+        return self::$translatedAttributeNames[$organizationTypeModelName];
+    }
+
+    public static function getAllChildClasses(): array
+    {
+        $result = [];
+        try {
+            $pluginCodeObj = new PluginCode('Csatar.Csatar');
+
+            $models = ModelModel::listPluginModels($pluginCodeObj);
+
+            $pluginCodeStr = $pluginCodeObj->toCode();
+            $pluginModelsNamespace = $pluginCodeObj->toPluginNamespace() . '\\Models\\';
+            foreach ($models as $model) {
+                $fullClassName = $pluginModelsNamespace . $model->className;
+
+                if(!is_subclass_of($fullClassName, self::getModelName())){
+                    continue;
+                };
+
+                $result[$fullClassName] = '\\' . $fullClassName;
+            }
+        } catch (Exception $ex) {
+            // Ignore invalid plugins and models
+        }
+
+        return $result;
+    }
+}

--- a/csatar-plugins/csatar/models/Scout.php
+++ b/csatar-plugins/csatar/models/Scout.php
@@ -391,31 +391,19 @@ class Scout extends OrganizationBase
         return $this->getFullName();
     }
 
-    /**
-     * Returns the id of the association to which the item belongs to.
-     */
-    public function getAssociationId()
-    {
-        if ($this->team_id) {
-            return $this->team->district->association->id;
-        }
-
-        return null;
-    }
-
     public function scopeOrganization($query, $mandate_model_type, $mandate_model_id)
     {
         switch ($mandate_model_type) {
-            case Association::getOrganizationTypeModelName():
+            case Association::getModelName():
                 $districts = \Csatar\Csatar\Models\District::where('association_id', $mandate_model_id)->lists('id');
                 $teams = \Csatar\Csatar\Models\Team::whereIn('district_id', $districts)->lists('id');
                 return $query->whereIn('team_id', $teams);
 
-            case District::getOrganizationTypeModelName():
+            case District::getModelName():
                 $teams = \Csatar\Csatar\Models\Team::where('district_id', $mandate_model_id)->lists('id');
                 return $query->whereIn('team_id', $teams);
 
-            case Team::getOrganizationTypeModelName():
+            case Team::getModelName():
                 return $query->where('team_id', $mandate_model_id);
 
             default:
@@ -489,7 +477,7 @@ class Scout extends OrganizationBase
         return $scoutMandateTypeIds;
     }
 
-    public function getMandatesForOrganization(OrganizationBase $organization) {
+    public function getMandatesForOrganization(PermissionBasedAccess $organization) {
         return $this->getMandatesInAssociation($organization->getAssociationId(), $this->updated_at);
     }
 
@@ -516,7 +504,7 @@ class Scout extends OrganizationBase
 
         $isOwn = false;
         if(Auth::user() && !empty(Auth::user()->scout)){
-            $isOwn = $model->isOwnOrganization(Auth::user()->scout);
+            $isOwn = $model->isOwnModel(Auth::user()->scout);
         }
 
         $is2fa = false;
@@ -541,7 +529,7 @@ class Scout extends OrganizationBase
             return;
         }
 
-        $key = $associationId . $model::getOrganizationTypeModelName() . ($own ? '_own' : '');
+        $key = $associationId . $model::getModelName() . ($own ? '_own' : '');
 
         $sessionRecordForModel = $sessionRecord->get($key);
 
@@ -553,7 +541,7 @@ class Scout extends OrganizationBase
     }
 
     public function saveRightsForModelToSession($model, $rightsForModel, $associationId, $own) {
-        $modelName = $model::getOrganizationTypeModelName();
+        $modelName = $model::getModelName();
         $key = $associationId . $modelName . ($own ? '_own' : '');
         $sessionRecord = Session::get('scout.rightsForModels');
 
@@ -574,7 +562,7 @@ class Scout extends OrganizationBase
         Session::put('scout.rightsForModels', $sessionRecord);
     }
 
-    public function isOwnOrganization($scout){
+    public function isOwnModel($scout){
         return $this->id === $scout->id;
     }
 

--- a/csatar-plugins/csatar/models/TeamReport.php
+++ b/csatar-plugins/csatar/models/TeamReport.php
@@ -8,7 +8,7 @@ use Csatar\Csatar\Models\Scout;
 /**
  * Model
  */
-class TeamReport extends Model
+class TeamReport extends PermissionBasedAccess
 {
     use \October\Rain\Database\Traits\Validation;
 

--- a/csatar-plugins/csatar/updates/TestData.php
+++ b/csatar-plugins/csatar/updates/TestData.php
@@ -1,5 +1,6 @@
 <?php namespace Csatar\Csatar\Updates;
 
+use RainLab\Builder\Classes\ComponentHelper;
 use Seeder;
 use Csatar\Csatar\Models\Association;
 use Csatar\Csatar\Models\District;
@@ -7,6 +8,7 @@ use Csatar\Csatar\Models\Patrol;
 use Csatar\Csatar\Models\Team;
 use Csatar\Csatar\Models\Troop;
 use Csatar\Csatar\Models\MandateType;
+use Csatar\Csatar\Models\PermissionBasedAccess;
 use Db;
 
 class TestData extends Seeder
@@ -407,20 +409,18 @@ class TestData extends Seeder
 
         if(empty($associationId)) return;
 
-        $mandateTypeModels = Db::table('csatar_csatar_mandate_types')
-            ->where('association_id', $associationId)
-            ->select('organization_type_model_name')->distinct()->get()->pluck('organization_type_model_name'); //get every unique model we have mandate for
+        $permissionBasedModels = PermissionBasedAccess::getAllChildClasses(); //get every model that needs permissions
         $scoutMandateTypeId = Db::table('csatar_csatar_mandate_types')->select('id')
             ->where('association_id', $associationId)
             ->where('organization_type_model_name', '\Csatar\Csatar\Models\Scout')
             ->first()->id; //get scout mandate type id
 
-        if(empty($mandateTypeModels) || empty($scoutMandateTypeId)) return;
+        if(empty($permissionBasedModels) || empty($scoutMandateTypeId)) return;
 
-        foreach ($mandateTypeModels as $mandateTypeModel) {
-            if($mandateTypeModel == MandateType::MODEL_NAME_GUEST) return;
+        foreach ($permissionBasedModels as $permissionBasedModel) {
+            if($permissionBasedModel == MandateType::MODEL_NAME_GUEST) return;
 
-            $model = new $mandateTypeModel();
+            $model = new $permissionBasedModel();
             $fields = $model->fillable ?? [];
             $relationArrays = ['belongsTo', 'belongsToMany', 'hasMany', 'attachOne', 'hasOne', 'morphTo', 'morphOne',
                 'morphMany', 'morphToMany', 'morphedByMany', 'attachMany', 'hasManyThrough', 'hasOneThrough'];
@@ -432,7 +432,7 @@ class TestData extends Seeder
             //add permission for the model in general
             Db::table('csatar_csatar_mandates_permissions')
                 ->updateOrInsert(
-                    [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $mandateTypeModel, 'field' => 'MODEL_GENERAL', 'own' => 0],
+                    [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $permissionBasedModel, 'field' => 'MODEL_GENERAL', 'own' => 0],
                     [
                         'create'        => 2,
                         'read'          => 2,
@@ -444,7 +444,7 @@ class TestData extends Seeder
             //add permission for the model in general for own
             Db::table('csatar_csatar_mandates_permissions')
                 ->updateOrInsert(
-                    [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $mandateTypeModel, 'field' => 'MODEL_GENERAL', 'own' => 1],
+                    [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $permissionBasedModel, 'field' => 'MODEL_GENERAL', 'own' => 1],
                     [
                         'create'        => 2,
                         'read'          => 2,
@@ -460,7 +460,7 @@ class TestData extends Seeder
                 //add permission for the model->field
                 Db::table('csatar_csatar_mandates_permissions')
                     ->updateOrInsert(
-                        [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $mandateTypeModel, 'field' => $field, 'own' => 0],
+                        [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $permissionBasedModel, 'field' => $field, 'own' => 0],
                         [
                             'create'        => 2,
                             'read'          => 2,
@@ -472,7 +472,7 @@ class TestData extends Seeder
                 //add permission for the model->field for own
                 Db::table('csatar_csatar_mandates_permissions')
                     ->updateOrInsert(
-                        [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $mandateTypeModel, 'field' => $field, 'own' => 1],
+                        [ 'mandate_type_id' => $scoutMandateTypeId, 'model' => $permissionBasedModel, 'field' => $field, 'own' => 1],
                         [
                             'create'        => 2,
                             'read'          => 2,
@@ -490,21 +490,19 @@ class TestData extends Seeder
 
         if(empty($associationId)) return;
 
-        $mandateTypeModels = Db::table('csatar_csatar_mandate_types')
-            ->where('association_id', $associationId)
-            ->select('organization_type_model_name')->distinct()->get()->pluck('organization_type_model_name'); //get every unique model we have mandate for
+        $permissionBasedModels = PermissionBasedAccess::getAllChildClasses(); //get every model that needs permissions
         $patrolLeaderMandateTypeId = Db::table('csatar_csatar_mandate_types')->select('id')
             ->where('association_id', $associationId)
             ->where('organization_type_model_name', '\Csatar\Csatar\Models\Patrol')
             ->whereNull('parent_id')
             ->first()->id; //get Patrol leader mandate type id
 
-        if(empty($mandateTypeModels) || empty($patrolLeaderMandateTypeId)) return;
+        if(empty($permissionBasedModels) || empty($patrolLeaderMandateTypeId)) return;
 
-        foreach ($mandateTypeModels as $mandateTypeModel) {
-            if($mandateTypeModel == MandateType::MODEL_NAME_GUEST) return;
+        foreach ($permissionBasedModels as $permissionBasedModel) {
+            if($permissionBasedModel == MandateType::MODEL_NAME_GUEST) return;
 
-            $model = new $mandateTypeModel();
+            $model = new $permissionBasedModel();
             $fields = $model->fillable ?? [];
             $relationArrays = ['belongsTo', 'belongsToMany', 'hasMany', 'attachOne', 'hasOne', 'morphTo', 'morphOne',
                 'morphMany', 'morphToMany', 'morphedByMany', 'attachMany', 'hasManyThrough', 'hasOneThrough'];
@@ -516,7 +514,7 @@ class TestData extends Seeder
             //add permission for the model in general
             Db::table('csatar_csatar_mandates_permissions')
                 ->updateOrInsert(
-                    [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $mandateTypeModel, 'field' => 'MODEL_GENERAL', 'own' => 0],
+                    [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $permissionBasedModel, 'field' => 'MODEL_GENERAL', 'own' => 0],
                     [
                         'create'        => 2,
                         'read'          => 2,
@@ -528,7 +526,7 @@ class TestData extends Seeder
             //add permission for the model in general for own
             Db::table('csatar_csatar_mandates_permissions')
                 ->updateOrInsert(
-                    [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $mandateTypeModel, 'field' => 'MODEL_GENERAL', 'own' => 1],
+                    [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $permissionBasedModel, 'field' => 'MODEL_GENERAL', 'own' => 1],
                     [
                         'create'        => 2,
                         'read'          => 2,
@@ -542,7 +540,7 @@ class TestData extends Seeder
                 //add permission for the model->field
                 Db::table('csatar_csatar_mandates_permissions')
                     ->updateOrInsert(
-                        [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $mandateTypeModel, 'field' => $field, 'own' => 0],
+                        [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $permissionBasedModel, 'field' => $field, 'own' => 0],
                         [
                             'create'        => 2,
                             'read'          => 2,
@@ -554,7 +552,7 @@ class TestData extends Seeder
                 //add permission for the model->field for own
                 Db::table('csatar_csatar_mandates_permissions')
                     ->updateOrInsert(
-                        [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $mandateTypeModel, 'field' => $field, 'own' => 1],
+                        [ 'mandate_type_id' => $patrolLeaderMandateTypeId, 'model' => $permissionBasedModel, 'field' => $field, 'own' => 1],
                         [
                             'create'        => 2,
                             'read'          => 2,
@@ -569,9 +567,7 @@ class TestData extends Seeder
 
     public function addReadPermissionsToGuests() {
         $associationIds = Association::all()->pluck('id')->toArray();
-        $mandateTypeModels = Db::table('csatar_csatar_mandate_types')
-            ->where('organization_type_model_name', '<>', 'GUEST')
-            ->select('organization_type_model_name')->distinct()->get()->pluck('organization_type_model_name'); //get every unique model we have mandate for
+        $permissionBasedModels = PermissionBasedAccess::getAllChildClasses(); //get every model that needs permissions
 
         foreach ($associationIds as $associationId) {
             $guestMandateTypeId = Db::table('csatar_csatar_mandate_types')->select('id')
@@ -579,11 +575,11 @@ class TestData extends Seeder
                 ->where('organization_type_model_name', 'GUEST')
                 ->first()->id; //get guest mandate type id
 
-            if(empty($mandateTypeModels) || empty($guestMandateTypeId)) return;
+            if(empty($permissionBasedModels) || empty($guestMandateTypeId)) return;
 
-            foreach ($mandateTypeModels as $mandateTypeModel) {
+            foreach ($permissionBasedModels as $permissionBasedModel) {
 
-                $model = new $mandateTypeModel();
+                $model = new $permissionBasedModel();
                 $fields = $model->fillable ?? [];
                 $relationArrays = ['belongsTo', 'belongsToMany', 'hasMany', 'attachOne', 'hasOne', 'morphTo', 'morphOne',
                     'morphMany', 'morphToMany', 'morphedByMany', 'attachMany', 'hasManyThrough', 'hasOneThrough'];
@@ -595,7 +591,7 @@ class TestData extends Seeder
                 //add permission for the model in general
                 Db::table('csatar_csatar_mandates_permissions')
                     ->updateOrInsert(
-                        [ 'mandate_type_id' => $guestMandateTypeId, 'model' => $mandateTypeModel, 'field' => 'MODEL_GENERAL', 'own' => 0],
+                        [ 'mandate_type_id' => $guestMandateTypeId, 'model' => $permissionBasedModel, 'field' => 'MODEL_GENERAL', 'own' => 0],
                         [
                             'read'          => 2,
                         ]
@@ -607,7 +603,7 @@ class TestData extends Seeder
                     //add permission for the model->field
                     Db::table('csatar_csatar_mandates_permissions')
                         ->updateOrInsert(
-                            [ 'mandate_type_id' => $guestMandateTypeId, 'model' => $mandateTypeModel, 'field' => $field, 'own' => 0],
+                            [ 'mandate_type_id' => $guestMandateTypeId, 'model' => $permissionBasedModel, 'field' => $field, 'own' => 0],
                             [
                                 'read'          => 2,
                             ]


### PR DESCRIPTION
- Refactored Model structure, removed not organization related functions from OrganizationBase.php and created PermissionBasedAccess.php model.
- Refactored TestData.php seeder, to include all PermissionBasedAccess.php child model when seeding permissions.