### PR TITLE
CS-336 Extended Personal Identification Number validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- CS-430 - added option and menu to list all team reports in association regardless of team id
+- CS-336 - Extended Personal Identification Number validation
+- CS-430 - Added option and menu to list all team reports in association regardless of team id
 - CS-418 - Create member card model
 - CS-431 - separated inactive and active scouts on team page
 - CS-415 - inactive districts and teams are hidden in structure accordions and menu

--- a/csatar-plugins/csatar/lang/en/lang.php
+++ b/csatar-plugins/csatar/lang/en/lang.php
@@ -167,6 +167,8 @@ return [
                     'dateInTheFutureError' => 'The selected Date for the %name %category is in the future.',
                     'invalidPersonalIdentificationNumber' => 'Invalid Personal Identification Number.',
                     'legalRepresentativePhoneUnderAge' => 'For scouts under legal age, phone number of one parent or legal representative must be filled.',
+                    'uniquePersonalIdentificationNumber' => 'This Personal Identification Number is already used for a scout.',
+                    'personalIdentificationNumberBirthdateMismatch' => 'Birthdate doesn\'t match with Personal Identification Number.',
                 ],
                 'staticMessages' => [
                     'personalDataNotAccepted' => 'Please verify your personal data here!',
@@ -373,7 +375,10 @@ return [
                 'teamFee' => 'Team fee',
                 'membershipFee' => 'Membership fee',
                 'currency' => 'Currency',
-                'personalIdentificationNumberValidator' => 'Personal Identification Number Validator',
+                'personalIdentificationNumberValidator' => 'Personal Identification Number Validation',
+                'unique'    => 'Unigue',
+                'required'  => 'Required',
+                'cnp'       => 'CNP - Romanian Personal Identification Number Validator',
                 'validationExceptions' => [
                     'invalidTeamReportSubmissionPeriod' => 'Team report submit period end date must be after start date.',
                 ],
@@ -709,7 +714,6 @@ return [
                 'attachmentsComment' => 'Max. five files can be uploaded',
                 'attachmentsValidationException' => 'Max. five files can be uploaded',
                 'created_by' => 'Created by',
-                'accidentLogRecordList' => 'Accident Log Record List',
             ],
         ],
         'oauth' => [

--- a/csatar-plugins/csatar/lang/hu/lang.php
+++ b/csatar-plugins/csatar/lang/hu/lang.php
@@ -165,6 +165,8 @@
                     'dateInTheFutureError' => 'A Dátum a %name %category esetén nem lehet a jövőben.',
                     'invalidPersonalIdentificationNumber' => 'Érvénytelen személyi szám.',
                     'legalRepresentativePhoneUnderAge' => 'Kiskorú cserkés esetén kötelező megadni az egyik szülő vagy törvényes képviselő telefonszámát.',
+                    'uniquePersonalIdentificationNumber' => 'Ezzel a személyi számmal már be van vezetve egy cserkész.',
+                    'personalIdentificationNumberBirthdateMismatch' => 'A születési dátum nem fel meg a személyi számban megadott születési dátumnak.',
                 ],
                 'staticMessages' => [
                     'personalDataNotAccepted' => 'Kérlek ellenőrizd, hogy helyesek-e a személyes adataid itt!',
@@ -371,7 +373,10 @@
                 'teamFee' => 'Csapat fenntartói díj',
                 'membershipFee' => 'Tagdíj értéke',
                 'currency' => 'Pénznem',
-                'personalIdentificationNumberValidator' => 'Személyi szám hitelesítő',
+                'personalIdentificationNumberValidator' => 'Személyi szám hitelesítés',
+                'unique'    => 'Egyedi',
+                'required'  => 'Kötelező',
+                'cnp'       => 'CNP - Romániai személy szám formátum hitelesítő',
                 'validationExceptions' => [
                     'invalidTeamReportSubmissionPeriod' => 'A csapatjelentés leadási periódus végének dátuma nagyobb kell legyen a periódus kezdetének dátumánál!',
                 ],

--- a/csatar-plugins/csatar/models/Association.php
+++ b/csatar-plugins/csatar/models/Association.php
@@ -20,6 +20,8 @@ class Association extends OrganizationBase
      */
     protected static $searchable = ['name'];
 
+    protected $jsonable = ['personal_identification_number_validator'];
+
     /**
      * @var array Validation rules
      */
@@ -137,7 +139,11 @@ class Association extends OrganizationBase
     }
 
     public function getPersonalIdentificationNumberValidatorOptions() {
-        return ['cnp' => 'CNP'];
+        return [
+            'unique:csatar_csatar_scouts'   => Lang::get('csatar.csatar::lang.plugin.admin.association.unique'),
+            'required'                      => Lang::get('csatar.csatar::lang.plugin.admin.association.required'),
+            'cnp'                           => Lang::get('csatar.csatar::lang.plugin.admin.association.cnp'),
+        ];
     }
 
     public function getAssociation() {

--- a/csatar-plugins/csatar/models/Scout.php
+++ b/csatar-plugins/csatar/models/Scout.php
@@ -7,6 +7,7 @@ use Csatar\Csatar\Models\Association;
 use Csatar\Csatar\Models\Mandate;
 use Csatar\Csatar\Models\MandateType;
 use Csatar\Csatar\Models\MembershipCard;
+use Csatar\Csatar\Classes\Validators\CnpValidator;
 use DateTime;
 use Db;
 use Flash;
@@ -15,6 +16,7 @@ use Log;
 use Model;
 use October\Rain\Database\Collection;
 use Session;
+use ValidationException;
 
 /**
  * Model
@@ -205,6 +207,7 @@ class Scout extends OrganizationBase
         $this->customMessages['mothers_phone.required_without_all'] = e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.legalRepresentativePhoneUnderAge'));
         $this->customMessages['fathers_phone.required_without_all'] = e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.legalRepresentativePhoneUnderAge'));
         $this->customMessages['legal_representative_phone.required_without_all'] = e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.legalRepresentativePhoneUnderAge'));
+        $this->customMessages['personal_identification_number.unique'] = e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.uniquePersonalIdentificationNumber'));
     }
 
     /**
@@ -217,8 +220,17 @@ class Scout extends OrganizationBase
                 return;
             }
 
-            if (!empty($this->team->district->association->personal_identification_number_validator)) {
-                $this->rules['personal_identification_number'] .= '|' . $this->team->district->association->personal_identification_number_validator;
+            $personalIdentificationNumberValidators = $this->getPersonalIdentificationNumberValidators();
+
+            if (!empty($personalIdentificationNumberValidators)) {
+                $this->rules['personal_identification_number'] .= '|' . implode('|', $personalIdentificationNumberValidators);
+            }
+
+            if (in_array('cnp', $personalIdentificationNumberValidators)
+                && !empty($this->personal_identification_number)
+                && (new DateTime($this->birthdate))->format('Y-m-d') != $this->getBirthDateFromCNP($this->personal_identification_number)
+            ) {
+                throw new \ValidationException(['birthdate' => Lang::get('csatar.csatar::lang.plugin.admin.scout.validationExceptions.personalIdentificationNumberBirthdateMismatch')]);
             }
 
             // if the selected troop does not belong to the selected team, then throw and exception
@@ -337,6 +349,10 @@ class Scout extends OrganizationBase
         // populate the Legal Relationships dropdown with legal relationships that belong to the selected team's association
         if (isset($fields->legal_relationship)) {
             $fields->legal_relationship->options = $this->team ? \Csatar\Csatar\Models\LegalRelationship::associationId($this->team->district->association->id)->lists('name', 'id') : [];
+        }
+
+        if (isset($fields->personal_identification_number) && in_array('cnp', $this->getPersonalIdentificationNumberValidators())) {
+            $fields->birthdate->value = $this->getBirthDateFromCNP($fields->personal_identification_number->value);
         }
     }
 
@@ -927,5 +943,59 @@ class Scout extends OrganizationBase
     {
         $this->accepted_at = new \DateTime();
         return $this->save();
+    }
+
+    /**
+     * @return string
+     */
+    public function getBirthDateFromCNP($cnp): string
+    {
+        if (empty($cnp)) {
+            return e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.invalidPersonalIdentificationNumber'));
+        }
+
+        if (!(new CnpValidator())->validate(null, $cnp, null)) {
+            throw new ValidationException([
+                'personal_identification_number' => e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.invalidPersonalIdentificationNumber'))]
+            );
+        }
+
+        $sex   = substr($cnp, 0, 1);
+        $year  = substr($cnp, 1, 2);
+        $month = substr($cnp, 3, 2);
+        $day   = substr($cnp, 5, 2);
+
+        switch ($sex) {
+            case 1:
+            case 2:
+            case 7:
+            case 8:
+                $year += 1900;
+                break;
+            case 3:
+            case 4:
+                $year += 2000;
+                break;
+            case 5:
+            case 6:
+                $year += 1800;
+                break;
+            default:
+                return e(trans('csatar.csatar::lang.plugin.admin.scout.validationExceptions.invalidPersonalIdentificationNumber'));
+        }
+
+        return $year . '-' . $month . '-' . $day;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPersonalIdentificationNumberValidators(): array
+    {
+        if (!empty($this->team)) {
+            return $this->team->district->association->personal_identification_number_validator;
+        }
+
+        return [];
     }
 }

--- a/csatar-plugins/csatar/models/association/fields.yaml
+++ b/csatar-plugins/csatar/models/association/fields.yaml
@@ -143,7 +143,7 @@ fields:
         label: 'csatar.csatar::lang.plugin.admin.association.personalIdentificationNumberValidator'
         emptyOption: 'csatar.csatar::lang.plugin.admin.general.select'
         span: auto
-        type: dropdown
+        type: checkboxlist
     team_report_submit_start_date:
         label: 'csatar.csatar::lang.plugin.admin.teamReport.submit_start_date'
         mode: date

--- a/csatar-plugins/csatar/models/scout/fields.yaml
+++ b/csatar-plugins/csatar/models/scout/fields.yaml
@@ -222,6 +222,7 @@ fields:
         yearRange: '100'
         span: auto
         type: datepicker
+        dependsOn: personal_identification_number
         formBuilder:
             type: field
             card: birthData


### PR DESCRIPTION
Extended Personal Identification Number validation:
- added option to association to set different validation types
- added autofill based on CNP to birthday
- added extra validation to check CNP and birthday matching

Removed duplicated array key from lang.php