### PR TITLE
CS-411 Fixed the header on the team page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- CS-411 - Fixed the header on the team page, so neither the image, nor the header will overflow the screen
+
 ## 1.9.0
 ### 2023-02-17
 

--- a/csatar-theme/assets/css/csatar-custom-styles.css
+++ b/csatar-theme/assets/css/csatar-custom-styles.css
@@ -1845,6 +1845,11 @@ a.login:link, a.login:visited, a.login:active {
     margin-bottom: 100px;
 }
 
+[aria-labelledby="about-us-tab"] img {
+    max-width: 100%;
+    height: auto;
+}
+
 /* Removing form, input, btn, etc. highlighting */
 
 input:focus,


### PR DESCRIPTION
- set image width to 100%, so neither the image, nor the header will overflow the screen.