### PR TITLE
CS-480 - Fixed leadership qualification not showing in downloaded TeamReport pdf

### DIFF
--- a/csatar-plugins/csatar/components/TeamReport.php
+++ b/csatar-plugins/csatar/components/TeamReport.php
@@ -220,7 +220,7 @@ class TeamReport extends ComponentBase
                 'legal_relationship'       => $scout->legal_relationship,
                 'legal_relationship_id'    => $scout->legal_relationship->id,
                 'leadership_qualification' => $scout->leadership_qualifications->sortByDesc(function ($item, $key) {
-                    return $item['pivot']['date'];
+                    return $item->id; // currently leadership qualifications are seeded in the correct order, so the highest id is the highest qualification, but if this changes, this should be changed to sort by the qualification level, and qualification level should be added to the leadership_qualifications table
                 })->values()->first(),
                 'ecset_code'               => $scout->ecset_code,
                 'membership_fee'           => $membership_fee,

--- a/csatar-plugins/csatar/components/teamreport/fullForm.htm
+++ b/csatar-plugins/csatar/components/teamreport/fullForm.htm
@@ -55,7 +55,7 @@
         %}
     {% endif %}
 
-    {% if __SELF__.action == 'modositas' %}
+    {% if user.scout %}
         {% partial '@dataRequestButton'
             permissionValue = 1
             dataRequest = __SELF__ ~ '::onDownloadPdf'

--- a/csatar-plugins/csatar/updates/SeederData.php
+++ b/csatar-plugins/csatar/updates/SeederData.php
@@ -170,7 +170,7 @@ class SeederData extends Seeder
             'Felnőtt őrsvezető képzés',
             'Segédvezető képzés',
             'Cserkész vezető',
-        ],
+        ], // if new leader qualification is added, and it's level is below 'Cserkész vezető', qualification_level column must be introduced, and leadership qualifications must be sorter by level
         'form'                      => [
             [
                 'title' => 'Tag',

--- a/csatar-plugins/csatar/views/pdf/layouts/teamreportlayout.htm
+++ b/csatar-plugins/csatar/views/pdf/layouts/teamreportlayout.htm
@@ -131,7 +131,7 @@ name = "Team Report layout"
             </tr>
         </thead>
         <tbody>
-            {% for scout in teamReport.scouts %}
+            {% for scout in teamReport.scouts.lists('pivot') %}
             <tr>
                 <td>{{ scout.name }}</td>
                 <td>{{ scout.legal_relationship.name }}</td>


### PR DESCRIPTION
- Fixed leadership qualification not showing in downloaded TeamReport pdf
- Modified leadership qualification saving to TeamReport, so not the most recently added qualification is saved, but the one with the highest qualification level (currently with the highest id)
- Modified Download Teamreport button to be visible for every logged in scout