### PR TITLE
CS-474 - Delete Scout name if inactivated more than 5 years ago

### DIFF
--- a/csatar-plugins/csatar/Plugin.php
+++ b/csatar-plugins/csatar/Plugin.php
@@ -8,6 +8,7 @@ use Csatar\Csatar\Models\MandateType;
 use Csatar\Csatar\Models\Scout;
 use Csatar\Csatar\Classes\ContentPageSearchProvider;
 use Csatar\Csatar\Classes\OrganizationSearchProvider;
+use Db;
 use Event;
 use Input;
 use Media\Classes\MediaLibrary;
@@ -302,5 +303,15 @@ class Plugin extends PluginBase
         ];
     }
 
-
+    public function registerSchedule($schedule)
+    {
+        $schedule->call(function () {
+            Db::select(
+                'UPDATE csatar_csatar_scouts
+                SET family_name = "Inaktivítás miatt törölt név", given_name = family_name
+                WHERE inactivated_at < DATE_SUB(NOW(), INTERVAL 5 YEAR) AND family_name <> "Inaktivítás miatt törölt név";'
+            );
+        })
+            ->daily();
+    }
 }

--- a/csatar-plugins/csatar/classes/StructureTree.php
+++ b/csatar-plugins/csatar/classes/StructureTree.php
@@ -137,7 +137,7 @@ class StructureTree
             'csatar_csatar_scouts.team_id',
             'csatar_csatar_scouts.troop_id',
             'csatar_csatar_scouts.patrol_id',
-            'csatar_csatar_scouts.is_active',
+            'csatar_csatar_scouts.inactivated_at',
         );
     }
 

--- a/csatar-plugins/csatar/components/CheckScoutStatus.php
+++ b/csatar-plugins/csatar/components/CheckScoutStatus.php
@@ -66,7 +66,7 @@ class CheckScoutStatus extends ComponentBase
 
         $variablesToPass = [
             'code' =>   $this->scoutCode,
-            'is_active' => $scout->is_active,
+            'is_active' => $scout->inactivated_at == null ? true : false,
             'is_exists' => true,
             'team_id' => $team->id,
             'team_name' => $team->name,

--- a/csatar-plugins/csatar/components/OrganizationUnitFrontend.php
+++ b/csatar-plugins/csatar/components/OrganizationUnitFrontend.php
@@ -254,6 +254,10 @@ class OrganizationUnitFrontend extends ComponentBase
                     $dataRow[] = $countryMap[$record->{$attribute}] ?? '';
                     continue;
                 }
+                if ($attribute == 'is_active') {
+                    $dataRow[] = $record->inactivated_at ? '0' : '1';
+                    continue;
+                }
                 $dataRow[] = strval($record->{$attribute});
             }
 
@@ -319,7 +323,7 @@ class OrganizationUnitFrontend extends ComponentBase
                     continue;
                 }
                 if ($scout->is_active != Status::ACTIVE) {
-                    $scout->is_active = empty($scout->is_active) ? Status::INACTIVE : $scout->is_active;
+                    $scout->inactivated_at = empty($scout->inactivated_at) ? date('Y-m-d H:i:s') : $scout->inactivated_at;
                     $scout->ignoreValidation = true;
                     $scout->forceSave();
                 } else {

--- a/csatar-plugins/csatar/components/TeamReport.php
+++ b/csatar-plugins/csatar/components/TeamReport.php
@@ -215,7 +215,7 @@ class TeamReport extends ComponentBase
 
     public function getScouts($teamId): void
     {
-        $scouts = Scout::where('team_id', $teamId)->where('is_active', true)->get();
+        $scouts = Scout::where('team_id', $teamId)->whereNull('inactivated_at', true)->get();
         $this->totalAmount = $this->teamFee;
         $this->scoutsWithoutRegistrationForm = TeamReportModel::getScoutsWithoutRegistrationForm($scouts);
 

--- a/csatar-plugins/csatar/controllers/MembershipCardRequests.php
+++ b/csatar-plugins/csatar/controllers/MembershipCardRequests.php
@@ -78,7 +78,7 @@ class MembershipCardRequests extends Controller
             ->whereNotNull('csatar_csatar_team_reports.submitted_at')
             ->whereNull('csatar_csatar_team_reports.deleted_at')
             ->whereNull('csatar_csatar_scouts.deleted_at')
-            ->where('csatar_csatar_scouts.is_active', Status::ACTIVE)
+            ->whereNull('csatar_csatar_scouts.inactivated_at')
             ->where('csatar_csatar_team_reports_scouts.legal_relationship_id', $memberLegalRelationshipId)
             ->whereNotIn('csatar_csatar_team_reports_scouts.scout_id', \Db::table('csatar_csatar_membership_cards')->pluck('scout_id'))
             ->orderBy('csatar_csatar_teams.team_number')

--- a/csatar-plugins/csatar/models/Mandate.php
+++ b/csatar-plugins/csatar/models/Mandate.php
@@ -241,7 +241,7 @@ class Mandate extends Model
         }
 
         // from the Organization pages: populate the Scouts dropdown
-        $scouts = Scout::where('is_active', true)->organization($mandate_model_type, $mandate_model_id)->get();
+        $scouts = Scout::whereNull('inactivated_at')->organization($mandate_model_type, $mandate_model_id)->get();
         $options = [];
         foreach ($scouts as $item) {
             $options[$item->id] = $item->name;

--- a/csatar-plugins/csatar/models/MembershipCard.php
+++ b/csatar-plugins/csatar/models/MembershipCard.php
@@ -51,7 +51,7 @@ class MembershipCard extends Model
     public function beforeValidate()
     {
         // if the scout assigned to this card is inactive, then this card cannot be set to active
-        if ($this->active == 1 && $this->scout->is_active != 1) {
+        if ($this->active == 1 && $this->scout->inactivated_at != null) {
             throw new ValidationException(['active' => Lang::get('csatar.csatar::lang.plugin.admin.membershipCard.inactiveScoutError')]);
         }
     }

--- a/csatar-plugins/csatar/models/Patrol.php
+++ b/csatar-plugins/csatar/models/Patrol.php
@@ -201,8 +201,8 @@ class Patrol extends OrganizationBase
     public function afterSave() {
         if (isset($this->original['status']) && $this->status != $this->original['status'] && $this->original['status'] == Status::ACTIVE) {
             // it would be more efficient to use mass update here, but in that case model events are not fired
-            foreach (Scout::where(['patrol_id' => $this->id, 'is_active' => Status::ACTIVE])->get() as $scout) {
-                $scout->is_active = Status::INACTIVE;
+            foreach (Scout::where('patrol_id', $this->id)->whereNull('inactivated_at')->get() as $scout) {
+                $scout->inactivated_at = date('Y-m-d H:i:s');
                 $scout->ignoreValidation = true;
                 $scout->forceSave();
             }

--- a/csatar-plugins/csatar/models/Scout.php
+++ b/csatar-plugins/csatar/models/Scout.php
@@ -125,7 +125,6 @@ class Scout extends OrganizationBase
         'phone',
         'personal_identification_number',
         'gender',
-        'is_active',
         'legal_relationship_id',
         'special_diet_id',
         'religion_id',
@@ -233,6 +232,16 @@ class Scout extends OrganizationBase
      * Add custom validation
      */
     public function beforeValidate() {
+        if ($this->is_active == 0 && $this->getOriginalValue('inactivated_at') == null) {
+            $this->inactivated_at = date('Y-m-d H:i:s');
+        }
+
+        if ($this->is_active == 1 && $this->getOriginalValue('inactivated_at') != null) {
+            $this->inactivated_at = null;
+        }
+
+        unset($this->is_active);
+
         if (!$this->ignoreValidation) {
             // if we don't have all the data for this validation, then return. The 'required' validation rules will be triggered
             if (!isset($this->team_id)) {
@@ -240,7 +249,7 @@ class Scout extends OrganizationBase
             }
 
             // personal id number validations, for active scouts only
-            if ($this->is_active) {
+            if ($this->inactivated_at == null) {
                 $personalIdentificationNumberValidators = $this->getPersonalIdentificationNumberValidators();
 
                 if (in_array('cnp', $personalIdentificationNumberValidators) && $this->shouldNotValidateCnp()) {
@@ -297,9 +306,9 @@ class Scout extends OrganizationBase
     }
 
     public function afterSave() {
-        if (isset($this->original['is_active'])
-            && $this->is_active != $this->original['is_active']
-            && $this->original['is_active'] == Status::ACTIVE) {
+        if (isset($this->original['inactivated_at'])
+            && $this->inactivated_at != $this->original['inactivated_at']
+            && $this->original['inactivated_at'] == null) {
             Mandate::where('scout_id', $this->id)->update(['end_date' => date('Y-m-d')]);
 
             if (!empty($this->membership_cards)) {
@@ -325,7 +334,7 @@ class Scout extends OrganizationBase
 
     public function updateCache(): void
     {
-        if ($this->wasRecentlyCreated && $this->is_active == Status::ACTIVE) {
+        if ($this->wasRecentlyCreated && $this->inactivated_at == null) {
             StructureTree::updateTeamTree($this->team_id);
         }
 
@@ -333,7 +342,7 @@ class Scout extends OrganizationBase
             return;
         }
 
-        if (($this->getOriginalValue('is_active') != $this->is_active) || $this->deleted_at != null) {
+        if (($this->getOriginalValue('inactivated_at') != $this->inactivated_at) || $this->deleted_at != null) {
             StructureTree::updateTeamTree($this->team_id);
         }
 
@@ -504,6 +513,8 @@ class Scout extends OrganizationBase
         if (isset($fields->citizenship_country) && empty($fields->citizenship_country->value)) {
             $fields->citizenship_country->value = Country::where('code', 'RO')->first()->id ?? null;
         }
+
+        $fields->is_active->value = $this->inactivated_at == null;
     }
 
     /**
@@ -878,17 +889,11 @@ class Scout extends OrganizationBase
     }
 
     public function scopeActive($query) {
-        return $query->where(function($query) {
-            $query->where('is_active', Status::ACTIVE)
-                ->orWhere('is_active', Status::FORMING);
-        });
+        return $query->whereNull('inactivated_at');
     }
 
     public function scopeInactive($query) {
-        return $query->where(function($query) {
-            $query->where('is_active', Status::INACTIVE)
-                ->orWhere('is_active', Status::SUSPENDED);
-        });
+        return $query->whereNotNull('inactivated_at');
     }
 
     public function scopeActiveScoutsInTeam($query, $id)

--- a/csatar-plugins/csatar/models/ScoutImport.php
+++ b/csatar-plugins/csatar/models/ScoutImport.php
@@ -156,6 +156,12 @@ class ScoutImport extends \Backend\Models\ImportModel
                 $scout = Scout::firstOrNew([
                     'ecset_code' => $data['ecset_code'],
                 ]);
+
+                if ($data['is_active'] != 1) {
+                    $scout->inactivated_at = $scout->inactivated_at == null ? date('Y-m-d H:i:s') : $scout->inactivated_at;
+                    $scout->ignoreValidation = true;
+                    unset($data['is_active']);
+                }
                 $scout->fill($data);
 
                 // generate an empty registration form

--- a/csatar-plugins/csatar/models/Team.php
+++ b/csatar-plugins/csatar/models/Team.php
@@ -237,8 +237,8 @@ class Team extends OrganizationBase
                 $patrol->ignoreValidation = true;
                 $patrol->forceSave();
             }
-            foreach (Scout::where(['team_id' => $this->id, 'is_active' => Status::ACTIVE])->get() as $scout) {
-                $scout->is_active = Status::INACTIVE;
+            foreach (Scout::where('team_id', $this->id)->whereNull('inactivated_at')->get() as $scout) {
+                $scout->inactivated_at = date('Y-m-d H:i:s');
                 $scout->ignoreValidation = true;
                 $scout->forceSave();
             }

--- a/csatar-plugins/csatar/models/TeamReport.php
+++ b/csatar-plugins/csatar/models/TeamReport.php
@@ -152,7 +152,7 @@ class TeamReport extends PermissionBasedAccess
             return;
         }
         // save the scouts (the pivot data can be saved only after the team report has been created)
-        $scouts = Scout::where('team_id', $this->team_id)->where('is_active', true)->get();
+        $scouts = Scout::where('team_id', $this->team_id)->whereNull('inactivated_at')->get();
         $scoutsToSync = [];
         $this->total_amount = $this->team_fee;
 

--- a/csatar-plugins/csatar/models/Troop.php
+++ b/csatar-plugins/csatar/models/Troop.php
@@ -157,8 +157,8 @@ class Troop extends OrganizationBase
                 $patrol->ignoreValidation = true;
                 $patrol->forceSave();
             }
-            foreach (Scout::where(['troop_id' => $this->id, 'is_active' => Status::ACTIVE])->get() as $scout) {
-                $scout->is_active = Status::INACTIVE;
+            foreach (Scout::where('troop_id', $this->id)->whereNull('inactivated_at')->get() as $scout) {
+                $scout->inactivated_at = date('Y-m-d H:i:s');
                 $scout->ignoreValidation = true;
                 $scout->forceSave();
             }

--- a/csatar-plugins/csatar/models/scout/columns.yaml
+++ b/csatar-plugins/csatar/models/scout/columns.yaml
@@ -82,8 +82,8 @@ columns:
     is_active:
         label: 'csatar.csatar::lang.plugin.admin.scout.isActive'
         type: switch
-        searchable: true
-        sortable: true
+        searchable: false
+        sortable: false
     is_approved:
         label: 'csatar.csatar::lang.plugin.admin.scout.isApproved'
         type: switch

--- a/csatar-plugins/csatar/updates/builder_table_update_csatar_csatar_scouts_7.php
+++ b/csatar-plugins/csatar/updates/builder_table_update_csatar_csatar_scouts_7.php
@@ -1,0 +1,38 @@
+<?php namespace Csatar\Csatar\Updates;
+
+use Db;
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableUpdateCsatarCsatarScouts7 extends Migration
+{
+    public function up()
+    {
+        Schema::table('csatar_csatar_scouts', function($table)
+        {
+            $table->dateTime('inactivated_at')->nullable();
+        });
+
+        Db::select('UPDATE csatar_csatar_scouts SET inactivated_at = updated_at WHERE is_active = 0');
+
+        Schema::table('csatar_csatar_scouts', function($table)
+        {
+            $table->dropColumn('is_active');
+        });
+    }
+    
+    public function down()
+    {
+        Schema::table('csatar_csatar_scouts', function($table)
+        {
+            $table->boolean('is_active')->default(0)->nullable();
+        });
+
+        Db::select('UPDATE csatar_csatar_scouts SET is_active = 1 WHERE inactivated_at IS NULL');
+
+        Schema::table('csatar_csatar_scouts', function($table)
+        {
+            $table->dropColumn('inactivated_at');
+        });
+    }
+}

--- a/csatar-plugins/csatar/updates/version.yaml
+++ b/csatar-plugins/csatar/updates/version.yaml
@@ -237,3 +237,6 @@
 1.0.82:
     - 'Updated table csatar_csatar_scouts'
     - builder_table_update_csatar_csatar_scouts_6.php
+1.0.83:
+    - 'Update csatar_csatar_scouts, change is_active bool to inactivated_at timestamp'
+    - builder_table_update_csatar_csatar_scouts_7.php


### PR DESCRIPTION
- Changed Scout model's is_active bool attribute to inactivated_at timestamp and updated logic accordingly
- Added daily scheduled action to check scouts with inactivation date later than 5 years and remove their names from database