### PR TITLE
CS-585_Fixed_appearances_of_grid_and_cards

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- CS-585 - Fixed card title line break in case of long titles
+- CS-585 - Fixed distance and line height of texts inside cards
+- CS-585 - Fixed the display of the list component on mobile
 - CodeFactor issue fix: Duplicate Code
 - CodeFactor issue fix: maintainability
 - CS-583 - CodeFactor issue fix: reduced complexity in form builder methods

--- a/csatar-plugins/csatar/components/recordlist/tableRow.htm
+++ b/csatar-plugins/csatar/components/recordlist/tableRow.htm
@@ -30,8 +30,8 @@
                     {% set tooltip = value %}
                 {% endif %}
                 <div class="col-12 col-md-4 col-lg mb-2 mb-lg-0 overflow-hidden" data-bs-toggle="tooltip" title="{{ tooltip }}">
-                    <div class="td label d-block d-lg-none">{{ column['label'] }}</div>
-                    <div class="td data grid-ellipsis">{{ value }}</div>
+                    <div class="td label d-block d-lg-none nottable">{{ column['label'] }}</div>
+                    <div class="td data grid-ellipsis nottable">{{ value }}</div>
                 </div>
             {% endfor %}
         </div>

--- a/csatar-plugins/csatar/components/recordlist/tableRow.htm
+++ b/csatar-plugins/csatar/components/recordlist/tableRow.htm
@@ -29,9 +29,9 @@
                 {% else %}
                     {% set tooltip = value %}
                 {% endif %}
-                <div class="col-6 col-md-4 col-lg mb-2 mb-lg-0 overflow-hidden" data-bs-toggle="tooltip" title="{{ tooltip }}">
-                    <p class="td label d-block d-lg-none">{{ column['label'] }}</p>
-                    <p class="td data grid-ellipsis">{{ value }}</p>
+                <div class="col-12 col-md-4 col-lg mb-2 mb-lg-0 overflow-hidden" data-bs-toggle="tooltip" title="{{ tooltip }}">
+                    <div class="td label d-block d-lg-none">{{ column['label'] }}</div>
+                    <div class="td data grid-ellipsis">{{ value }}</div>
                 </div>
             {% endfor %}
         </div>

--- a/csatar-plugins/csatar/components/recordlist/tableRow.htm
+++ b/csatar-plugins/csatar/components/recordlist/tableRow.htm
@@ -30,8 +30,8 @@
                     {% set tooltip = value %}
                 {% endif %}
                 <div class="col-12 col-md-4 col-lg mb-2 mb-lg-0 overflow-hidden" data-bs-toggle="tooltip" title="{{ tooltip }}">
-                    <div class="td label d-block d-lg-none nottable">{{ column['label'] }}</div>
-                    <div class="td data grid-ellipsis nottable">{{ value }}</div>
+                    <div class="td label d-block d-lg-none">{{ column['label'] }}</div>
+                    <div class="td data grid-ellipsis">{{ value }}</div>
                 </div>
             {% endfor %}
         </div>

--- a/csatar-plugins/csatar/models/scout/fields.yaml
+++ b/csatar-plugins/csatar/models/scout/fields.yaml
@@ -231,7 +231,7 @@ fields:
         formBuilder:
             type: card
             position: sheets
-            class: 'col-lg-4 col-md-12 col-sm-12'
+            class: 'col-xl-4 col-lg-6 col-md-12 col-sm-12'
             color: csat-data-birth
             order: 1
     birthdate:
@@ -278,7 +278,7 @@ fields:
         formBuilder:
             type: card
             position: sheets
-            class: 'col-lg-4 col-md-12 col-sm-12'
+            class: 'col-xl-4 col-lg-6 col-md-12 col-sm-12'
             color: csat-data-address
             order: 2
     address_country:
@@ -350,7 +350,7 @@ fields:
         formBuilder:
             type: card
             position: sheets
-            class: 'col-lg-4 col-md-12 col-sm-12'
+            class: 'col-xl-4 col-lg-6 col-md-12 col-sm-12'
             color: csat-data-occupation
             order: 3
     occupation:
@@ -376,7 +376,7 @@ fields:
         formBuilder:
             type: card
             position: sheets
-            class: 'col-lg-4 col-md-12 col-sm-12'
+            class: 'col-xl-4 col-lg-6 col-md-12 col-sm-12'
             color: csat-data-parent
             order: 4
     mothers_name:
@@ -410,7 +410,7 @@ fields:
         formBuilder:
             type: card
             position: sheets
-            class: 'col-lg-4 col-md-12 col-sm-12'
+            class: 'col-xl-4 col-lg-6 col-md-12 col-sm-12'
             color: csat-data-parent
             order: 5
     fathers_name:
@@ -444,7 +444,7 @@ fields:
         formBuilder:
             type: card
             position: sheets
-            class: 'col-lg-4 col-md-12 col-sm-12'
+            class: 'col-xl-4 col-lg-6 col-md-12 col-sm-12'
             color: csat-data-parent
             order: 6
     legal_representative_name:

--- a/csatar-plugins/forms/components/basicform/partials/sheetCard.htm
+++ b/csatar-plugins/forms/components/basicform/partials/sheetCard.htm
@@ -6,16 +6,16 @@
                     <a href="{{ '#csat-data-collapse-' ~ name | replace({' ' : '-'}) }}" data-bs-toggle="collapse" aria-expanded="false" aria-controls="{{ 'csat-data-collapse-' ~ name | replace({' ' : '-'}) }}">
                         <img class="p-2 not-auto-height" src="{{ 'assets/images/csat_data_card_deco.svg' | theme }}" alt="" />
                     </a>
-                    <p class="p-title">{{ name }}</p>
+                    <p class="p-title cardtitle">{{ name }}</p>
                     <hr>
                     <div class="row collapse collapse-on-sm" id="{{ 'csat-data-collapse-' ~ name | replace({' ' : '-'}) }}">
                         {% for field in fields %}
                             {% if name == 'Leírás' or name == 'Csapat története' or name == 'Vezetőség bemutatása' %}
                             <div class="col-12">
                             {% else %}
-                            <div class="col-lg-6 col-md-6 col-sm-12">
+                            <div class="col-lg-6 col-md-6 col-sm-12 mb-3">
                             {% endif %}
-                                <p class="p-small mb-2 text-subtitle">{{ field.label }}</p>
+                                <p class="p-small-card mb-0 text-subtitle">{{ field.label }}</p>
                                 {% if field.raw %}
                                     <p class="card-text">{{ field.value|raw }}</p>
                                 {% else %}

--- a/csatar-theme/assets/css/csatar-custom-styles.css
+++ b/csatar-theme/assets/css/csatar-custom-styles.css
@@ -184,11 +184,22 @@ p.justify {
     line-height: 1.7;
 }
 
+.p-small-card {
+    font-family: geomanist !important;
+    font-weight: 200;
+    font-size: calc(0.8rem + 0.2vw);
+    line-height: 1;
+}
+
 .p-title {
     font-family: geomanist !important;
     font-weight: 400;
     font-size: calc(0.9rem + 0.2vw);
     line-height: 1.5;
+}
+
+.cardtitle {
+    max-width: 90%;
 }
 
 .p-gallery {
@@ -258,6 +269,10 @@ body>p.flash-message.success, body>p.flash-message.info, body>p.flash-message.wa
 
 label {
     font-weight: 300;
+}
+
+.td.label {
+    font-weight: 400;
 }
 
 .font-pw-400 {
@@ -1489,14 +1504,13 @@ div.card.csat-resp-gdtable > div.row > div.col, div.col-6, div.col-md-4, div.col
         border-width: 0px !important;
     }
 
-    div.table.csat-grid > div:nth-child(odd) > div > div .td {
+    #tableRows-recordList > a:nth-child(odd) > div > div > div > div > div.td.data.grid-ellipsis {
         background-color: #F5F5F5;
-        }
-
-    div.table.csat-grid > div:nth-child(even) > div > div .td {
+    }
+    
+    #tableRows-recordList > a:nth-child(even) > div > div > div > div > div.td.data.grid-ellipsis {
         background-color: white;
-        }
-
+    }
 }
 
 @media (max-width: 991px) {
@@ -1640,7 +1654,13 @@ table.fixed {
 th, td, .th, .td, .th-grid {
     border-radius: 12px;
     padding: 4px;
-    min-height: 35px;
+}
+
+@media (min-width: 992px) {
+
+    th, td, .th, .td, .th-grid {
+        min-height: 35px;
+    }
 }
 
 #tableRows .td {

--- a/csatar-theme/assets/css/csatar-custom-styles.css
+++ b/csatar-theme/assets/css/csatar-custom-styles.css
@@ -1704,10 +1704,10 @@ td, .td {
     vertical-align: top;
 }
 
-table tr:nth-child(odd) td, div div.row:nth-child(odd) div.td {
+table tr:nth-child(odd) td, div div.row:nth-child(odd) div.td:not(.nottable) {
     background-color: #F5F5F5;
 }
-table tr:nth-child(even) td, div div.row:nth-child(even) div.td {
+table tr:nth-child(even) td, div div.row:nth-child(even) div.td:not(.nottable) {
     background-color: white;
 }
 

--- a/csatar-theme/assets/css/csatar-custom-styles.css
+++ b/csatar-theme/assets/css/csatar-custom-styles.css
@@ -1503,14 +1503,6 @@ div.card.csat-resp-gdtable > div.row > div.col, div.col-6, div.col-md-4, div.col
     .csat-border-lg-none {
         border-width: 0px !important;
     }
-
-    #tableRows-recordList > a:nth-child(odd) > div > div > div > div > div.td.data.grid-ellipsis {
-        background-color: #F5F5F5;
-    }
-    
-    #tableRows-recordList > a:nth-child(even) > div > div > div > div > div.td.data.grid-ellipsis {
-        background-color: white;
-    }
 }
 
 @media (max-width: 991px) {
@@ -1704,15 +1696,28 @@ td, .td {
     vertical-align: top;
 }
 
-table tr:nth-child(odd) td, div div.row:nth-child(odd) div.td:not(.nottable) {
-    background-color: #F5F5F5;
-}
-table tr:nth-child(even) td, div div.row:nth-child(even) div.td:not(.nottable) {
-    background-color: white;
-}
-
 .table_top_no_border {
     border-top: none !important;
+}
+
+/* Alternating line colors for grids and tables */
+
+@media (min-width: 992px) {
+    div.table.csat-grid a:nth-child(odd) div.td, div.csat-grid div.tr:nth-child(odd) div.td {
+        background-color: #F5F5F5;
+    }
+    
+    div.table.csat-grid a:nth-child(even) div.td, div.csat-grid div.tr:nth-child(even) div.td {
+        background-color: white;
+    }
+}
+
+table tr:nth-child(odd) td {
+    background-color: #F5F5F5;
+}
+
+table tr:nth-child(even) td {
+    background-color: white;
 }
 
 /* Pick a date calendar */


### PR DESCRIPTION
- Fixed the display of the list component (grid) on mobile
     - Label and content are now on separate lines.
     - All lines have full width
     - The distance between the label and the content made smaller
     - there are "div" elements instead of "p" elements in the cells
- Fixed card title line break in case of long titles
- Fixed distance and line height of texts inside cards

